### PR TITLE
Add LICENSE disclaimer for 3pp

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,12 @@ The compiled `unit-test` executable can be found under `/code/build/ut/unit-test
 
 Check the [docs](/docs/) for more information about the project
 
-[1]: https://gerrit.ericsson.se/#/settings/http-password
+# License
+
+The Software implemented in this repository is distributed under MIT license,
+as stated in the [LICENSE](/LICENSE) file. It makes use of some
+[boost C++ library](https://www.boost.org/doc/libs/1_67_0/) functionalities,
+which have their own [license](https://www.boost.org/LICENSE_1_0.txt).
+Hermes core functionality is based on [nghttp2](https://nghttp2.org/), and
+json handling is done with [rapidjson](https://rapidjson.org/), both under
+MIT license.


### PR DESCRIPTION
This commit adds a note in the READEME.md file to make
clear that it relies on some third parties. Despite this
code is under the MIT license, those libraries used/linked
are properly referenced.