### PR TITLE
add_coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
     - run: cmake . -B build
     - run: make -j -C build
     - run:  apk add lcov --update-cache --repository  http://dl-3.alpinelinux.org/alpine/edge/testing/
-    - run: lcov -i --capture --directory "./build/src/" --output-file base-coverage.info --no-external --directory "./" --exclude '*/ut/*'
+    - run: lcov -i --capture --directory "${{ github.workspace }}/build/src/" --output-file base-coverage.info --no-external --directory "${{ github.workspace }}/" --exclude '*/ut/*'
     - run: ./build/ut/unit-test
-    - run: lcov --capture --directory "./build/src/" --output-file test-coverage.info --no-external --directory "./" --exclude '*/ut/*'
+    - run: lcov --capture --directory "${{ github.workspace }}/build/src/" --output-file test-coverage.info --no-external --directory "${{ github.workspace }}/" --exclude '*/ut/*'
     - run: lcov -a base-coverage.info  -a test-coverage.info  -o total-coverage.info
 
     - name: Coveralls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
     - run: cmake . -B build
     - run: make -j -C build
     - run:  apk add lcov --update-cache --repository  http://dl-3.alpinelinux.org/alpine/edge/testing/
-    - run: lcov -i --capture --directory "/code/build/src/" --output-file base-coverage.info --no-external --directory "./" --exclude '*/ut/*'
+    - run: lcov -i --capture --directory "./build/src/" --output-file base-coverage.info --no-external --directory "./" --exclude '*/ut/*'
     - run: ./build/ut/unit-test
-    - run: lcov --capture --directory "/code/build/src/" --output-file test-coverage.info --no-external --directory "./" --exclude '*/ut/*'
+    - run: lcov --capture --directory "./build/src/" --output-file test-coverage.info --no-external --directory "./" --exclude '*/ut/*'
     - run: lcov -a base-coverage.info  -a test-coverage.info  -o total-coverage.info
 
     - name: Coveralls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       options: "--entrypoint sh"
     steps:
     - uses: actions/checkout@v2
-    - run: cmake . -B build
+    - run: cmake -B build  -DCMAKE_BUILD_TYPE=Debug .
     - run: make -j -C build
     - run: apk add lcov --update-cache --repository  http://dl-3.alpinelinux.org/alpine/edge/testing/
     - run: echo ${PWD}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,14 @@ jobs:
     - name: Install and setup lcov base
       run: |
           apk add lcov --update-cache --repository  http://dl-3.alpinelinux.org/alpine/edge/testing/
-          lcov -i --capture --directory "${PWD}/build/src/" --output-file base-coverage.info --no-external --directory "${PWD}/" --exclude '*/ut/*'
+          lcov -i --capture --directory "./build/src/" --output-file base-coverage.info --no-external --directory "./" --exclude '*/ut/*'
 
     - name: Run unit tests
       run: ./build/ut/unit-test
 
     - name: Capture and merge coverage info
       run: |
-          lcov --capture --directory "${PWD}/build/src/" --output-file test-coverage.info --no-external --directory "${PWD}/" --exclude '*/ut/*'
+          lcov --capture --directory "./build/src/" --output-file test-coverage.info --no-external --directory "./" --exclude '*/ut/*'
           lcov -a base-coverage.info  -a test-coverage.info  -o total-coverage.info
 
     - name: Upload coverage to Coveralls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,12 @@ jobs:
   formatting-check:
     name: Check code format
     runs-on: ubuntu-latest
+
     steps:
+
     - name: Checkout hermes repo
       uses: actions/checkout@v2
+
     - name: Run clang format
       run: |
           find . -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\|c\|hh\)' -exec clang-format -style=file -i {} \;
@@ -25,17 +28,32 @@ jobs:
     container:
       image: jgomezselles/hermes_base:0.0.1
       options: "--entrypoint sh"
-    steps:
-    - uses: actions/checkout@v2
-    - run: cmake -B build  -DCMAKE_BUILD_TYPE=Debug .
-    - run: make -j -C build
-    - run: apk add lcov --update-cache --repository  http://dl-3.alpinelinux.org/alpine/edge/testing/
-    - run: lcov -i --capture --directory "${PWD}/build/src/" --output-file base-coverage.info --no-external --directory "${PWD}/" --exclude '*/ut/*'
-    - run: ./build/ut/unit-test
-    - run: lcov --capture --directory "${PWD}/build/src/" --output-file test-coverage.info --no-external --directory "${PWD}/" --exclude '*/ut/*'
-    - run: lcov -a base-coverage.info  -a test-coverage.info  -o total-coverage.info
 
-    - name: Coveralls
+    steps:
+
+    - name: Checkout hermes repo
+      uses: actions/checkout@v2
+
+    - name: Run cmake with debug and coverage flags
+      run: cmake -B build -DCMAKE_BUILD_TYPE=Debug .
+
+    - name: Compile code and unit tests
+      run: make -j -C build
+
+    - name: Install and setup lcov base
+      run: |
+          apk add lcov --update-cache --repository  http://dl-3.alpinelinux.org/alpine/edge/testing/
+          lcov -i --capture --directory "${PWD}/build/src/" --output-file base-coverage.info --no-external --directory "${PWD}/" --exclude '*/ut/*'
+
+    - name: Run unit tests
+      run: ./build/ut/unit-test
+
+    - name: Capture and merge coverage info
+      run: |
+          lcov --capture --directory "${PWD}/build/src/" --output-file test-coverage.info --no-external --directory "${PWD}/" --exclude '*/ut/*'
+          lcov -a base-coverage.info  -a test-coverage.info  -o total-coverage.info
+
+    - name: Upload coverage to Coveralls
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,18 @@ on:
   pull_request:
 
 jobs:
+
   formatting-check:
     name: Check code format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: find . -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\|c\|hh\)' -exec clang-format -style=file -i {} \;
-    - run: expr length + "$(git diff)" "==" 0
+    - name: Checkout hermes repo
+      uses: actions/checkout@v2
+    - name: Run clang format
+      run: |
+          find . -regex '.*\.\(cpp\|hpp\|cc\|cxx\|h\|c\|hh\)' -exec clang-format -style=file -i {} \;
+          git diff --exit-code
+
   compile-and-unit-tests:
     name: Compile and run unit tests
     runs-on: ubuntu-latest
@@ -25,7 +30,6 @@ jobs:
     - run: cmake -B build  -DCMAKE_BUILD_TYPE=Debug .
     - run: make -j -C build
     - run: apk add lcov --update-cache --repository  http://dl-3.alpinelinux.org/alpine/edge/testing/
-    - run: echo ${PWD}
     - run: lcov -i --capture --directory "${PWD}/build/src/" --output-file base-coverage.info --no-external --directory "${PWD}/" --exclude '*/ut/*'
     - run: ./build/ut/unit-test
     - run: lcov --capture --directory "${PWD}/build/src/" --output-file test-coverage.info --no-external --directory "${PWD}/" --exclude '*/ut/*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,11 @@ jobs:
     - uses: actions/checkout@v2
     - run: cmake . -B build
     - run: make -j -C build
-    - run:  apk add lcov --update-cache --repository  http://dl-3.alpinelinux.org/alpine/edge/testing/
-    - run: lcov -i --capture --directory "${{ github.workspace }}/build/src/" --output-file base-coverage.info --no-external --directory "${{ github.workspace }}/" --exclude '*/ut/*'
+    - run: apk add lcov --update-cache --repository  http://dl-3.alpinelinux.org/alpine/edge/testing/
+    - run: echo ${PWD}
+    - run: lcov -i --capture --directory "${PWD}/build/src/" --output-file base-coverage.info --no-external --directory "${PWD}/" --exclude '*/ut/*'
     - run: ./build/ut/unit-test
-    - run: lcov --capture --directory "${{ github.workspace }}/build/src/" --output-file test-coverage.info --no-external --directory "${{ github.workspace }}/" --exclude '*/ut/*'
+    - run: lcov --capture --directory "${PWD}/build/src/" --output-file test-coverage.info --no-external --directory "${PWD}/" --exclude '*/ut/*'
     - run: lcov -a base-coverage.info  -a test-coverage.info  -o total-coverage.info
 
     - name: Coveralls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+
 jobs:
   formatting-check:
     name: Check code format
@@ -22,4 +24,14 @@ jobs:
     - uses: actions/checkout@v2
     - run: cmake . -B build
     - run: make -j -C build
+    - run:  apk add lcov --update-cache --repository  http://dl-3.alpinelinux.org/alpine/edge/testing/
+    - run: lcov -i --capture --directory "/code/build/src/" --output-file base-coverage.info --no-external --directory "./" --exclude '*/ut/*'
     - run: ./build/ut/unit-test
+    - run: lcov --capture --directory "/code/build/src/" --output-file test-coverage.info --no-external --directory "./" --exclude '*/ut/*'
+    - run: lcov -a base-coverage.info  -a test-coverage.info  -o total-coverage.info
+
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: total-coverage.info

--- a/.gitignore
+++ b/.gitignore
@@ -5,14 +5,4 @@
 build
 .idea
 cmake-build-*
-
-#document files
-images
-document.aux
-document.dvi
-document.fdb_latexmk
-document.fls
-document.log
-document.out.ps
-document.pdf
-document.toc
+**/*.info


### PR DESCRIPTION
This commit attempts to add all the coverage needed steps
into the CI workflow. It also adds the pull_request trigger, as
recommended in coveralls github.

Not sure that this will work, so some trial and error is
foreseen.