### PR TITLE
Includehttps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 .vscode
 build
 .idea
+.DS_Store
 cmake-build-*
 **/*.info

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,13 @@
 FROM jgomezselles/hermes_base:0.0.1 as builder
 
 COPY . /code
+
+WORKDIR /code/ut/ssl
+RUN ./generateCryptographicMaterial
+
 WORKDIR /code/build
-RUN  cmake -DCMAKE_BUILD_TYPE=Release .. && make -j4
+RUN  cmake -DCMAKE_BUILD_TYPE=Release .. && make -j4 \
+    && ./ut/unit-test --gtest_filter=-stats_test_extended.PrintAndWrite
 
 FROM alpine:latest
 COPY --from=builder /code/build/src/hermes /hermes/hermes

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk add build-base cmake wget tar linux-headers openssl-dev libev-dev openssl-libs-static
+RUN apk add build-base cmake wget tar linux-headers openssl-dev libev-dev openssl-libs-static openssl ca-certificates
 
 WORKDIR /code/build
 

--- a/src/http2_client/client_impl.cpp
+++ b/src/http2_client/client_impl.cpp
@@ -28,7 +28,7 @@ namespace http2_client
 {
 client_impl::client_impl(std::shared_ptr<stats::stats_if> st, boost::asio::io_context& io_ctx,
                          std::unique_ptr<traffic::script_queue_if> q, const std::string& h,
-                         const std::string& p, bool secure_session)
+                         const std::string& p, const bool secure_session)
     : stats(std::move(st)),
       io_ctx(io_ctx),
       queue(std::move(q)),
@@ -146,11 +146,11 @@ void client_impl::send()
         return;
     }
 
-    auto session = conn->get_session();
-    session->io_service().post([this, script, session, req] {
+    auto& session = conn->get_session();
+    session.io_service().post([this, script, &session, req] {
         boost::system::error_code ec;
         auto init_time = std::make_shared<time_point<steady_clock>>(steady_clock::now());
-        auto nghttp_req = session->submit(ec, req.method, req.url, req.body, req.headers);
+        auto nghttp_req = session.submit(ec, req.method, req.url, req.body, req.headers);
         if (!nghttp_req)
         {
             std::cerr << "Error submitting. Closing connection:" << ec.message() << std::endl;

--- a/src/http2_client/client_impl.hpp
+++ b/src/http2_client/client_impl.hpp
@@ -47,7 +47,7 @@ public:
 
     client_impl(std::shared_ptr<stats::stats_if> stats, boost::asio::io_context& io_ctx,
                 std::unique_ptr<traffic::script_queue_if> q, const std::string& h,
-                const std::string& p, bool secure_session = false);
+                const std::string& p, const bool secure_session = false);
 
     virtual ~client_impl() {}
 

--- a/src/http2_client/client_impl.hpp
+++ b/src/http2_client/client_impl.hpp
@@ -47,7 +47,7 @@ public:
 
     client_impl(std::shared_ptr<stats::stats_if> stats, boost::asio::io_context& io_ctx,
                 std::unique_ptr<traffic::script_queue_if> q, const std::string& h,
-                const std::string& p);
+                const std::string& p, bool secure_session = false);
 
     virtual ~client_impl() {}
 
@@ -74,6 +74,7 @@ private:
     std::unique_ptr<traffic::script_queue_if> queue;
     std::string host;
     std::string port;
+    bool secure_session;
     std::unique_ptr<connection> conn;
     std::shared_timed_mutex mtx;
 };

--- a/src/http2_client/connection.hpp
+++ b/src/http2_client/connection.hpp
@@ -38,7 +38,7 @@ public:
     };
 
 public:
-    connection(const std::string& host, const std::string& port, bool secure_session = false);
+    connection(const std::string& host, const std::string& port, const bool secure_session = false);
 
     connection(const connection& o) = delete;
     connection(connection&& o) = delete;
@@ -48,7 +48,7 @@ public:
     connection& operator=(const connection& o) = delete;
     connection& operator=(connection&& o) = delete;
 
-    std::shared_ptr<nghttp2::asio_http2::client::session> get_session() { return session; };
+    nghttp2::asio_http2::client::session& get_session() { return session; };
     const status& get_status() const { return connection_status; };
     bool wait_to_be_connected();
     void close();
@@ -62,7 +62,7 @@ private:
     /// ASIO attributes
     boost::asio::io_service io_service;
     boost::asio::io_service::work svc_work;
-    std::shared_ptr<nghttp2::asio_http2::client::session> session;
+    nghttp2::asio_http2::client::session session;
 
     /// Class attributes
     status connection_status;

--- a/src/http2_client/connection.hpp
+++ b/src/http2_client/connection.hpp
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <functional>
+#include <memory>
 #include <string>
 #include <thread>
 
@@ -37,7 +38,7 @@ public:
     };
 
 public:
-    connection(const std::string& host, const std::string& port);
+    connection(const std::string& host, const std::string& port, bool secure_session = false);
 
     connection(const connection& o) = delete;
     connection(connection&& o) = delete;
@@ -47,7 +48,7 @@ public:
     connection& operator=(const connection& o) = delete;
     connection& operator=(connection&& o) = delete;
 
-    nghttp2::asio_http2::client::session& get_session() { return session; };
+    std::shared_ptr<nghttp2::asio_http2::client::session> get_session() { return session; };
     const status& get_status() const { return connection_status; };
     bool wait_to_be_connected();
     void close();
@@ -61,7 +62,7 @@ private:
     /// ASIO attributes
     boost::asio::io_service io_service;
     boost::asio::io_service::work svc_work;
-    nghttp2::asio_http2::client::session session;
+    std::shared_ptr<nghttp2::asio_http2::client::session> session;
 
     /// Class attributes
     status connection_status;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,10 +154,9 @@ int main(int argc, char* argv[])
      * CLIENT
      ******************************************************************/
     auto q = std::make_unique<traffic::script_queue>(the_script.get());
-    auto client = std::make_unique<http2_client::client_impl>(stats, client_io_ctx, std::move(q),
-                                                              the_script->get_server_dns(),
-                                                              the_script->get_server_port(),
-                                                              the_script->is_server_secure());
+    auto client = std::make_unique<http2_client::client_impl>(
+        stats, client_io_ctx, std::move(q), the_script->get_server_dns(),
+        the_script->get_server_port(), the_script->is_server_secure());
     if (!client->is_connected())
     {
         std::cerr << "Terminating application. Error connecting server." << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,7 +156,8 @@ int main(int argc, char* argv[])
     auto q = std::make_unique<traffic::script_queue>(the_script.get());
     auto client = std::make_unique<http2_client::client_impl>(stats, client_io_ctx, std::move(q),
                                                               the_script->get_server_dns(),
-                                                              the_script->get_server_port());
+                                                              the_script->get_server_port(),
+                                                              the_script->is_server_secure());
     if (!client->is_connected())
     {
         std::cerr << "Terminating application. Error connecting server." << std::endl;

--- a/src/script/json_reader.cpp
+++ b/src/script/json_reader.cpp
@@ -92,6 +92,19 @@ int json_reader::get_value<int>(const std::string& path)
 }
 
 template <>
+bool json_reader::get_value<bool>(const std::string& path)
+{
+    const auto* value = rapidjson::Pointer(path.c_str()).Get(document);
+    if (value &&
+        (value->GetType() == rapidjson::kFalseType || value->GetType() == rapidjson::kTrueType) )
+    {
+        return value->GetBool();
+    }
+
+    throw std::logic_error("Bool not found in " + path);
+}
+
+template <>
 std::string json_reader::get_value<std::string>(const std::string& path)
 {
     const auto* value = rapidjson::Pointer(path.c_str()).Get(document);

--- a/src/script/json_reader.cpp
+++ b/src/script/json_reader.cpp
@@ -96,7 +96,7 @@ bool json_reader::get_value<bool>(const std::string& path)
 {
     const auto* value = rapidjson::Pointer(path.c_str()).Get(document);
     if (value &&
-        (value->GetType() == rapidjson::kFalseType || value->GetType() == rapidjson::kTrueType) )
+        (value->GetType() == rapidjson::kFalseType || value->GetType() == rapidjson::kTrueType))
     {
         return value->GetBool();
     }

--- a/src/script/json_reader.hpp
+++ b/src/script/json_reader.hpp
@@ -50,6 +50,9 @@ template <>
 int json_reader::get_value<int>(const std::string& path);
 
 template <>
+bool json_reader::get_value<bool>(const std::string& path);
+
+template <>
 std::string json_reader::get_value<std::string>(const std::string& path);
 
 template <>

--- a/src/script/script.hpp
+++ b/src/script/script.hpp
@@ -26,6 +26,7 @@ public:
     const range_type& get_ranges() const { return ranges; };
     const std::string& get_server_dns() const { return server.dns; };
     const std::string& get_server_port() const { return server.port; };
+    const bool is_server_secure() const { return server.secure; };
     const int get_timeout_ms() const { return timeout_ms; };
 
     const bool post_process(const answer_type& last_answer);

--- a/src/script/script_reader.cpp
+++ b/src/script/script_reader.cpp
@@ -97,14 +97,7 @@ server_info script_reader::build_server_info()
     server_info server;
     server.dns = get_value<std::string>("/dns");
     server.port = get_value<std::string>("/port");
-
-    if (is_present("/secure"))
-    {
-        server.secure = get_value<bool>("/secure");
-    } else
-    {
-        server.secure = false;
-    }
+    server.secure = is_present("/secure") ? get_value<bool>("/secure") : false;
 
     return server;
 }

--- a/src/script/script_reader.cpp
+++ b/src/script/script_reader.cpp
@@ -97,6 +97,15 @@ server_info script_reader::build_server_info()
     server_info server;
     server.dns = get_value<std::string>("/dns");
     server.port = get_value<std::string>("/port");
+
+    if (is_present("/secure"))
+    {
+        server.secure = get_value<bool>("/secure");
+    } else
+    {
+        server.secure = false;
+    }
+
     return server;
 }
 

--- a/src/script/script_schema.hpp
+++ b/src/script/script_schema.hpp
@@ -24,6 +24,9 @@ const std::string schema = R"(
     "port": {
       "type": "string"
     },
+    "secure": {
+      "type": "boolean"
+    },
     "timeout": {
       "type": "integer"
     },

--- a/src/script/script_sctructs.hpp
+++ b/src/script/script_sctructs.hpp
@@ -33,5 +33,6 @@ struct server_info
 {
     std::string dns;
     std::string port;
+    bool secure;
 };
 }  // namespace traffic

--- a/ut/helpers/json_object_builder.cpp
+++ b/ut/helpers/json_object_builder.cpp
@@ -61,10 +61,10 @@ json_object_builder &json_object_builder::manipulate_int(const std::string &key,
 }
 
 json_object_builder &json_object_builder::manipulate_bool(const std::string &key,
-                                                         const std::optional<bool> &element)
+                                                          const std::optional<bool> &element)
 {
     manipulate_element(key, element.has_value(),
-                       [element]() { return std::to_string(element.value()); });
+                       [element]() { return element.value() ? "true" : "false"; });
     return *this;
 }
 

--- a/ut/helpers/json_object_builder.cpp
+++ b/ut/helpers/json_object_builder.cpp
@@ -60,6 +60,14 @@ json_object_builder &json_object_builder::manipulate_int(const std::string &key,
     return *this;
 }
 
+json_object_builder &json_object_builder::manipulate_bool(const std::string &key,
+                                                         const std::optional<bool> &element)
+{
+    manipulate_element(key, element.has_value(),
+                       [element]() { return std::to_string(element.value()); });
+    return *this;
+}
+
 json_object_builder &json_object_builder::manipulate_object(
     const std::string &key, const std::optional<std::string> &element)
 {

--- a/ut/helpers/json_object_builder.hpp
+++ b/ut/helpers/json_object_builder.hpp
@@ -13,7 +13,8 @@ public:
     json_object_builder& manipulate_string(const std::string& key,
                                            const std::optional<std::string>& element);
     json_object_builder& manipulate_int(const std::string& key, const std::optional<int>& element);
-    json_object_builder& manipulate_bool(const std::string& key, const std::optional<bool>& element);
+    json_object_builder& manipulate_bool(const std::string& key,
+                                         const std::optional<bool>& element);
     json_object_builder& manipulate_object(const std::string& key,
                                            const std::optional<std::string>& element);
     json_object_builder& add_element(const std::string& key, const std::string& value);

--- a/ut/helpers/json_object_builder.hpp
+++ b/ut/helpers/json_object_builder.hpp
@@ -13,6 +13,7 @@ public:
     json_object_builder& manipulate_string(const std::string& key,
                                            const std::optional<std::string>& element);
     json_object_builder& manipulate_int(const std::string& key, const std::optional<int>& element);
+    json_object_builder& manipulate_bool(const std::string& key, const std::optional<bool>& element);
     json_object_builder& manipulate_object(const std::string& key,
                                            const std::optional<std::string>& element);
     json_object_builder& add_element(const std::string& key, const std::string& value);

--- a/ut/http2_client/tlsConnection_test.cpp
+++ b/ut/http2_client/tlsConnection_test.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+#include <nghttp2/asio_http2_server.h>
+
+#include <boost/system/error_code.hpp>
+
+#include "connection.hpp"
+
+using namespace std::chrono_literals;
+
+namespace http2_client
+{
+class connection_test : public ::testing::Test
+{
+public:
+    connection_test() : server_host("localhost"), server_port("8080"), server_started(false){};
+
+    void start_secure_server()
+    {
+        boost::system::error_code ec;
+        tlsCtx = std::make_unique<boost::asio::ssl::context>(boost::asio::ssl::context::sslv23);
+        tlsCtx->use_private_key_file("../ut/ssl/localhost.key", boost::asio::ssl::context::pem);
+        tlsCtx->use_certificate_chain_file("../ut/ssl/localhost.crt");
+        nghttp2::asio_http2::server::configure_tls_context_easy(ec, *tlsCtx);
+
+        boost::system::error_code server_error_code;
+
+        server = std::make_unique<nghttp2::asio_http2::server::http2>();
+
+        if (server->listen_and_serve(server_error_code, *tlsCtx, server_host, server_port, true))
+        {
+            fprintf(stderr, "Error starting server in %s:%s", server_host.c_str(),
+                    server_port.c_str());
+        }
+
+        server_started = true;
+    }
+
+    void stop_secure_server()
+    {
+        for (auto& service : server->io_services())
+        {
+            service->stop();
+        }
+
+        server->stop();
+        server->join();
+        server.reset();
+        server_started = false;
+    }
+
+    void SetUp() override { start_secure_server(); };
+
+    void TearDown() override
+    {
+        if (server_started)
+        {
+            stop_secure_server();
+        }
+    };
+
+protected:
+    std::unique_ptr<nghttp2::asio_http2::server::http2> server;
+    std::unique_ptr<boost::asio::ssl::context> tlsCtx;
+    const std::string server_host;
+    const std::string server_port;
+    bool server_started;
+};
+
+TEST_F(connection_test, correct_initialization)
+{
+    connection c(server_host, server_port, true);
+    ASSERT_TRUE(c.wait_to_be_connected());
+    ASSERT_EQ(connection::status::OPEN, c.get_status());
+}
+
+TEST_F(connection_test, wrong_port)
+{
+    testing::internal::CaptureStderr();
+
+    const std::string wrong_port = "1234";
+    connection c(server_host, wrong_port);
+
+    ASSERT_FALSE(c.wait_to_be_connected());
+    ASSERT_EQ(connection::status::CLOSED, c.get_status());
+
+    const std::string expected_output{"Error in connection to localhost:" + wrong_port +
+                                      " Message: Connection refused\n"};
+    ASSERT_EQ(expected_output, testing::internal::GetCapturedStderr());
+}
+
+TEST_F(connection_test, connection_is_lost_because_of_the_server)
+{
+    connection c(server_host, server_port, true);
+
+    ASSERT_TRUE(c.wait_to_be_connected());
+    ASSERT_EQ(connection::status::OPEN, c.get_status());
+    stop_secure_server();
+    ASSERT_TRUE(c.wait_for_status(100ms, connection::status::CLOSED));
+}
+
+TEST_F(connection_test, close_connection)
+{
+    connection c(server_host, server_port, true);
+
+    ASSERT_TRUE(c.wait_to_be_connected());
+    ASSERT_EQ(connection::status::OPEN, c.get_status());
+
+    // This test is unstable due to, despite the efforts on checking the status,
+    // the connection is not ready. Closing a connection which is not fully open
+    // ends up in the nghttp2 client in the following error:
+    // Assertion failed: !inside_callback_ (asio_client_session_impl.cc: enter_callback: 611)
+    std::this_thread::sleep_for(100ms);
+    c.close();
+
+    ASSERT_FALSE(c.wait_to_be_connected());
+    ASSERT_EQ(connection::status::CLOSED, c.get_status());
+}
+}  // namespace http2_client

--- a/ut/ssl/generateCryptographicMaterial
+++ b/ut/ssl/generateCryptographicMaterial
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Create the CA
+openssl genrsa -out rootCA.key 4096
+openssl req -x509 -new -nodes -key rootCA.key -subj "/C=ES/ST=es" -sha256 -days 1024 -out rootCA.crt
+
+# Make the container trust the CA
+cp rootCA.crt  /usr/local/share/ca-certificates/rootCA.crt
+update-ca-certificates
+
+# Generate localhost cryptographic material
+openssl genrsa -out localhost.key 2048
+openssl req -new -sha256 -key localhost.key -subj "/C=ES/ST=es/O=MyOrg, Inc./CN=localhost" -out localhost.csr
+# Verify the csr's content
+openssl req -in localhost.csr -noout -text
+
+# Generate the certificate using the mydomain csr and key along with the CA Root key
+openssl x509 -req -in localhost.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out localhost.crt -days 500 -sha256
+
+# Verify the certificate's content
+openssl x509 -in localhost.crt -text -noout


### PR DESCRIPTION
Hi @jgomezselles,

I have been using Hermes as traffic generator for a while and I thought that it would be awesome if it could use H2 and not only H2C. That is why I am creating this pull request.

This two changes make Hermes able to talk to HTTPS endpoints. Although it works, I am still working on the UTs for the HTTPS connection (managing self-signed certs and so) but I thought that it would be easier to start the conversation now. I will keep working on it and will make another pull request (or make a fix to the last commit, as you wish) once is done.

Cheers!