### PR TITLE
Fix kind action in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,10 @@ jobs:
       run: echo COMMIT_ID=${COMMIT_ID::7} >> $GITHUB_ENV
     -
       name: Install KinD
-      uses: engineerd/setup-kind@v0.5.0
+      uses: helm/kind-action@2a525709fd0874b75d7ae842d257981b0e0f557d
+      with:
+        cluster_name: "kind"
+        kubectl_version: "v1.22.1"
     -
       name: Download server-mock
       uses: actions/download-artifact@v2


### PR DESCRIPTION
The server version for the engineerd takes too long and
installs an old server that the client cannot talk to.
Trying a new one, setting the version of kubectl and also
hoping for it to take less than 5 mins. In their doc it
seems that the default is 1 min, so maybe that's a good sign.

Using a commit id since the fix hasn't been released yet.