### PR TITLE
hermes_base:0.0.2 - Bump up boost and nghttp versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     name: Compile and run unit tests
     runs-on: ubuntu-latest
     container:
-      image: jgomezselles/hermes_base:0.0.1
+      image: jgomezselles/hermes_base:0.0.2
       options: "--entrypoint sh"
     steps:
     -

--- a/doc/dev_info.md
+++ b/doc/dev_info.md
@@ -16,7 +16,7 @@ This is because in that way, builds are reproducible and maintaineble.
 Build a development image by running, from the root of this repository:
 
 ```bash
-docker run --rm -it -v "${PWD}":/code jgomezselles/hermes_base:0.0.1
+docker run --rm -it -v "${PWD}":/code jgomezselles/hermes_base:0.0.2
 ```
 
 In this way, you will be sharing your local copy of the repository with the development

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jgomezselles/hermes_base:0.0.1 as builder
+FROM jgomezselles/hermes_base:0.0.2 as builder
 
 COPY . /code
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,7 +14,7 @@ To do so, execute, from the root directory of your local repository, the
 following commands:
 
 ```bash
-docker build -f docker/base/Dockerfile . -t jgomezselles/hermes_base:0.0.1 # You may want to skip this one, and just pull it!
+docker build -f docker/base/Dockerfile . -t jgomezselles/hermes_base:0.0.2 # You may want to skip this one, and just pull it!
 docker build -f docker/Dockerfile . -t jgomezselles/hermes:<your_favorite_tag>
 ```
 

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -4,15 +4,15 @@ RUN apk add build-base cmake wget tar linux-headers openssl-dev libev-dev openss
 
 WORKDIR /code/build
 
-RUN set -x && wget https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0_rc2.tar.gz && \
+RUN set -x && wget https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz && \
     tar xvf boost* && cd boost* && ./bootstrap.sh && ./b2 -j4 install && cd .. && rm -rf * && set +x
 
 RUN set -x && wget  https://github.com/google/googletest/archive/2fe3bd9.tar.gz -O gtest.tar.gz && \
     tar xvf gtest.tar.gz && cd googletest* && cmake . && make -j4 install && cd .. && rm -rf * && set +x
 
-RUN set -x && wget https://github.com/nghttp2/nghttp2/releases/download/v1.39.2/nghttp2-1.39.2.tar.bz2 && \
-    tar xf nghttp2* && cd nghttp2* && ./configure --enable-asio-lib --disable-shared && make -j4 install && \
-    cd .. && rm -rf * && set +x
+RUN set -x && wget https://github.com/nghttp2/nghttp2/releases/download/v1.45.1/nghttp2-1.45.1.tar.bz2 && \
+    tar xf nghttp2* && cd nghttp2* && ./configure --enable-asio-lib --disable-shared --enable-python-bindings=no && \
+    make -j4 install && cd .. && rm -rf * && set +x
 
 RUN set -x && wget https://github.com/Tencent/rapidjson/archive/4b3d7c2.tar.gz -O rapidjson.tar.gz && \
     tar xf rapidjson.tar.gz && cd rapid* && \

--- a/src/http2_client/client_impl.cpp
+++ b/src/http2_client/client_impl.cpp
@@ -5,7 +5,7 @@
 
 #include <atomic>
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/system/error_code.hpp>
 #include <chrono>
 #include <iostream>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include <syslog.h>
 
 #include <boost/asio/steady_timer.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <chrono>
 #include <exception>
 #include <fstream>

--- a/src/sender/sender.cpp
+++ b/src/sender/sender.cpp
@@ -1,6 +1,6 @@
 #include "sender.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "client_impl.hpp"
 #include "params.hpp"

--- a/src/sender/sender.hpp
+++ b/src/sender/sender.hpp
@@ -1,5 +1,4 @@
 #include <atomic>
-#include <boost/bind.hpp>
 #include <future>
 
 #pragma once

--- a/src/stats/stats.cpp
+++ b/src/stats/stats.cpp
@@ -1,7 +1,7 @@
 #include "stats.hpp"
 
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <chrono>
 #include <cmath>
 #include <ctime>

--- a/src/stats/stats.hpp
+++ b/src/stats/stats.hpp
@@ -1,6 +1,5 @@
 #include <atomic>
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
 #include <chrono>
 #include <iostream>
 #include <map>

--- a/ut/http2_client/connection_test.cpp
+++ b/ut/http2_client/connection_test.cpp
@@ -48,21 +48,6 @@ public:
         server_started = true;
     }
 
-    void start_secure_server()
-    {
-        boost::system::error_code server_error_code;
-
-        server = std::make_unique<nghttp2::asio_http2::server::http2>();
-
-        if (server->listen_and_serve(server_error_code, server_host, server_port, true))
-        {
-            fprintf(stderr, "Error starting server in %s:%s", server_host.c_str(),
-                    server_port.c_str());
-        }
-
-        server_started = true;
-    }
-
     void stop_server()
     {
         for (auto& service : server->io_services())

--- a/ut/sender/timer_test.cpp
+++ b/ut/sender/timer_test.cpp
@@ -2,7 +2,6 @@
 
 #include <atomic>
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
 #include <chrono>
 #include <functional>
 #include <thread>


### PR DESCRIPTION
Boost bumped up to 1.76.0 from 1.67.0. Version 1.77.0 not used
because it makes the server crash every time the object is deleted.
This makes the unit test to not work.

A warning appeared for boost/bind, in which it's mandatory now
to use boost/bind/bind.hpp.

Nghttp2 version bumped up to 1.45.1, which is the latest.

Docker image for hermes_base generated and pushed manually, so all
documentation updated accordingly.