### PR TITLE
Use ghcr as primary registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     name: Compile and run unit tests
     runs-on: ubuntu-latest
     container:
-      image: jgomezselles/hermes_base:0.0.2
+      image: ghcr.io/jgomezselles/hermes_base:0.0.2
       options: "--entrypoint sh"
     steps:
     -
@@ -78,7 +78,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile
-          tags: jgomezselles/hermes:${{ env.COMMIT_ID }}
+          tags: ghcr.io/jgomezselles/hermes:${{ env.COMMIT_ID }}
           outputs: type=docker,dest=/tmp/hermes-image-${{ env.COMMIT_ID }}.tar
       -
         name: Upload artifact
@@ -109,7 +109,7 @@ jobs:
         with:
           context: .
           file: ./docker/server-mock/Dockerfile
-          tags: jgomezselles/server-mock:${{ env.COMMIT_ID }}
+          tags: ghcr.io/jgomezselles/server-mock:${{ env.COMMIT_ID }}
           outputs: type=docker,dest=/tmp/server-mock-image-${{ env.COMMIT_ID }}.tar
       -
         name: Upload artifact
@@ -152,8 +152,8 @@ jobs:
     -
       name: Load images to KinD
       run: |
-        kind load image-archive /tmp/server-mock-image-${{ env.COMMIT_ID }}.tar jgomezselles/server-mock:${{ env.COMMIT_ID }} --name kind
-        kind load image-archive /tmp/hermes-image-${{ env.COMMIT_ID }}.tar jgomezselles/hermes:${{ env.COMMIT_ID }} --name kind
+        kind load image-archive /tmp/server-mock-image-${{ env.COMMIT_ID }}.tar ghcr.io/jgomezselles/server-mock:${{ env.COMMIT_ID }} --name kind
+        kind load image-archive /tmp/hermes-image-${{ env.COMMIT_ID }}.tar ghcr.io/jgomezselles/hermes:${{ env.COMMIT_ID }} --name kind
     -
       name: Check previous steps
       run: |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ easily how hermes works.
 ## Container to Container example
 
 1. Build and run a server-mock container by following [these instructions](docker/README.md#server-mock).
-2. Attach to a docker container running a `jgomezselles/hermes` image, and create a script file
+2. Attach to a docker container running a `ghcr.io/jgomezselles/hermes` image, and create a script file
 like the one located in the helm [example](helm/example-hermes/templates/traffic.script.yaml).
 3. Run hermes providing the path to your new script:
 ```bash

--- a/doc/dev_info.md
+++ b/doc/dev_info.md
@@ -16,7 +16,7 @@ This is because in that way, builds are reproducible and maintaineble.
 Build a development image by running, from the root of this repository:
 
 ```bash
-docker run --rm -it -v "${PWD}":/code jgomezselles/hermes_base:0.0.2
+docker run --rm -it -v "${PWD}":/code ghcr.io/jgomezselles/hermes_base:0.0.2
 ```
 
 In this way, you will be sharing your local copy of the repository with the development

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jgomezselles/hermes_base:0.0.2 as builder
+FROM ghcr.io/jgomezselles/hermes_base:0.0.2 as builder
 
 COPY . /code
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,8 +14,8 @@ To do so, execute, from the root directory of your local repository, the
 following commands:
 
 ```bash
-docker build -f docker/base/Dockerfile . -t jgomezselles/hermes_base:0.0.2 # You may want to skip this one, and just pull it!
-docker build -f docker/Dockerfile . -t jgomezselles/hermes:<your_favorite_tag>
+docker build -f docker/base/Dockerfile . -t ghcr.io/jgomezselles/hermes_base:0.0.2 # You may want to skip this one, and just pull it!
+docker build -f docker/Dockerfile . -t ghcr.io/jgomezselles/hermes:<your_favorite_tag>
 ```
 
 ## Server mock
@@ -26,12 +26,12 @@ To build it, just run, from the root of this
 repository:
 
 ```bash
-docker build -f docker/server-mock/Dockerfile . -t jgomezselles/server-mock:local
+docker build -f docker/server-mock/Dockerfile . -t ghcr.io/jgomezselles/server-mock:local
 ```
 
 It will copy and build the code from [h2server.go](../ft/h2server.go), so you may later execute it
 by running:
 
 ```bash
-docker run --rm -it -p 0.0.0.0:8080:8080 jgomezselles/server-mock:local
+docker run --rm -it -p 0.0.0.0:8080:8080 ghcr.io/jgomezselles/server-mock:local
 ```

--- a/helm/example-hermes/values.yaml
+++ b/helm/example-hermes/values.yaml
@@ -17,4 +17,4 @@ hermes:
     cm: traffic-script-cm
   image:
     repository: ghcr.io/jgomezselles/hermes
-    tag: 0.0.1
+    tag: 0.0.2

--- a/helm/example-hermes/values.yaml
+++ b/helm/example-hermes/values.yaml
@@ -2,7 +2,7 @@ serverMock:
   name: server-mock
   replicaCount: 1
   image:
-    repository: jgomezselles/server-mock
+    repository: ghcr.io/jgomezselles/server-mock
     pullPolicy: Never
     tag: "local"
   podAnnotations:
@@ -16,5 +16,5 @@ hermes:
   script:
     cm: traffic-script-cm
   image:
-    repository: jgomezselles/hermes
+    repository: ghcr.io/jgomezselles/hermes
     tag: 0.0.1

--- a/helm/hermes/values.yaml
+++ b/helm/hermes/values.yaml
@@ -12,7 +12,7 @@ hermes:
   name: hermes
 
 image:
-  repository: jgomezselles/hermes
+  repository: ghcr.io/jgomezselles/hermes
   tag: 0.0.1
   pullPolicy: IfNotPresent
 

--- a/helm/hermes/values.yaml
+++ b/helm/hermes/values.yaml
@@ -13,7 +13,7 @@ hermes:
 
 image:
   repository: ghcr.io/jgomezselles/hermes
-  tag: 0.0.1
+  tag: 0.0.2
   pullPolicy: IfNotPresent
 
 script:


### PR DESCRIPTION
Dockerhub images will still be updated but the primary is
going to be ghcr.io/jgomezselles/hermes***.
Hopefully this will help to be more downloadable from organizations.

All references changed. If this commit succeeds, version 0.0.2 will be
released.