### PR TITLE
Fix Content-Type & Content-Length header keys

### DIFF
--- a/src/http2_client/client_utils.hpp
+++ b/src/http2_client/client_utils.hpp
@@ -17,8 +17,8 @@ namespace http2_client
 using nghttp2::asio_http2::header_map;
 using nghttp2::asio_http2::header_value;
 
-inline static const std::string CONTENT_TYPE = "content_type";
-inline static const std::string CONTENT_LENGTH = "content_length";
+inline static const std::string CONTENT_TYPE = "content-type";
+inline static const std::string CONTENT_LENGTH = "content-length";
 inline static const std::string APP_JSON = "application/json";
 
 struct race_control

--- a/ut/http2_client/client_utils_test.cpp
+++ b/ut/http2_client/client_utils_test.cpp
@@ -14,12 +14,12 @@ TEST(client_utils_test, BuildUri)
 
 void check_pre_built_headers(const size_t s, const header_map& built)
 {
-    auto element = built.find(CONTENT_TYPE);
+    auto element = built.find("content-type");
     ASSERT_NE(element, built.end());
-    ASSERT_EQ(element->second.value, APP_JSON);
+    ASSERT_EQ(element->second.value, "application/json");
     ASSERT_FALSE(element->second.sensitive);
 
-    element = built.find(CONTENT_LENGTH);
+    element = built.find("content-length");
     ASSERT_NE(element, built.end());
     ASSERT_EQ(element->second.value, std::to_string(8));
     ASSERT_FALSE(element->second.sensitive);


### PR DESCRIPTION
Hi @jgomezselles 

I have recently pulled the latest changes from the Hermes repo, and when using it to trigger a performance test over the services I maintain I found some errors in the execution. Investigation led me to discover this small bug. So here is a simple PR :)

Feel free to ask me for test it in the golang server mock if you think it is needed. I saw that it doesn't check for headers, so maybe this is the reason why you didn't notice that the header keys were misspelled.

We love Hermes, cheers!