### PR TITLE
Compile only hermes exec in release Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/jgomezselles/hermes_base:0.0.2 as builder
 COPY . /code
 
 WORKDIR /code/build
-RUN  cmake -DCMAKE_BUILD_TYPE=Release .. && make -j4
+RUN  cmake -DCMAKE_BUILD_TYPE=Release .. && make -j4 hermes
 
 FROM alpine:latest
 COPY --from=builder /code/build/src/hermes /hermes/hermes


### PR DESCRIPTION
Unit tests were alse being compiled, which made tests and CI going a bit slower.
With this change, only hermes executable is being compiled.