### PR TITLE
nixify hermes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build
 .DS_Store
 cmake-build-*
 **/*.info
+result
+

--- a/README.md
+++ b/README.md
@@ -29,63 +29,6 @@ Hermes may be used standalone (check the [releases](https://github.com/jgomezsel
 from a [docker container](#container-to-container-example), or as part of a kubernetes
 [deployment](#hermes-in-kubernetes-example).
 
-## Building & running with Nix
-
-If you have [Nix](https://nixos.org/) with flakes enabled:
-
-```bash
-# Run directly (builds and executes)
-nix run . -- -f traffic.json -r 100 -t 30
-
-# Build the binary
-nix build
-
-# Enter a dev shell with all dependencies
-nix develop
-```
-
-To install hermes into your system via `nix profile`:
-
-```bash
-nix profile install .
-```
-
-Or as a NixOS module input in your system flake:
-
-```nix
-{
-  inputs.hermes.url = "github:jgomezselles/hermes";
-
-  outputs = { hermes, ... }: {
-    nixosConfigurations.my-machine = {
-      environment.systemPackages = [ hermes.packages.x86_64-linux.default ];
-    };
-  };
-}
-```
-
-### Nix container image
-
-Build a container image (OCI tarball) and load it into Docker:
-
-```bash
-nix build .#container
-docker load < result
-docker run --rm localhost/hermes:latest -f /path/to/traffic.json
-```
-
-Compared to the [Dockerfile](docker/Dockerfile) approach:
-
-| Aspect | Dockerfile | Nix |
-|---|---|---|
-| Base image | Fedora 38 (~200 MB) | None — only the binary + runtime deps |
-| Final size | ~360 MB+ | **160 MB** |
-| Dependencies | Manually listed 30+ `.so` files (brittle) | Automatically resolved by Nix |
-| Reproducibility | Non-deterministic (dnf updates, network fetches) | Fully hermetic & cacheable |
-| Build time | Must build base + hermes sequentially | Fully cached by Nix store |
-| Boost version | 1.78.0 (Fedora 38) | 1.86.0 |
-| Build isolation | None — depends on host toolchain | Sandboxed build
-
 ## Executing hermes
 
 You may take a look to Hermes help by just typing `./hermes -h`:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,63 @@ Hermes may be used standalone (check the [releases](https://github.com/jgomezsel
 from a [docker container](#container-to-container-example), or as part of a kubernetes
 [deployment](#hermes-in-kubernetes-example).
 
+## Building & running with Nix
+
+If you have [Nix](https://nixos.org/) with flakes enabled:
+
+```bash
+# Run directly (builds and executes)
+nix run . -- -f traffic.json -r 100 -t 30
+
+# Build the binary
+nix build
+
+# Enter a dev shell with all dependencies
+nix develop
+```
+
+To install hermes into your system via `nix profile`:
+
+```bash
+nix profile install .
+```
+
+Or as a NixOS module input in your system flake:
+
+```nix
+{
+  inputs.hermes.url = "github:jgomezselles/hermes";
+
+  outputs = { hermes, ... }: {
+    nixosConfigurations.my-machine = {
+      environment.systemPackages = [ hermes.packages.x86_64-linux.default ];
+    };
+  };
+}
+```
+
+### Nix container image
+
+Build a container image (OCI tarball) and load it into Docker:
+
+```bash
+nix build .#container
+docker load < result
+docker run --rm localhost/hermes:latest -f /path/to/traffic.json
+```
+
+Compared to the [Dockerfile](docker/Dockerfile) approach:
+
+| Aspect | Dockerfile | Nix |
+|---|---|---|
+| Base image | Fedora 38 (~200 MB) | None — only the binary + runtime deps |
+| Final size | ~360 MB+ | **160 MB** |
+| Dependencies | Manually listed 30+ `.so` files (brittle) | Automatically resolved by Nix |
+| Reproducibility | Non-deterministic (dnf updates, network fetches) | Fully hermetic & cacheable |
+| Build time | Must build base + hermes sequentially | Fully cached by Nix store |
+| Boost version | 1.78.0 (Fedora 38) | 1.86.0 |
+| Build isolation | None — depends on host toolchain | Sandboxed build
+
 ## Executing hermes
 
 You may take a look to Hermes help by just typing `./hermes -h`:

--- a/doc/dev_info.md
+++ b/doc/dev_info.md
@@ -33,6 +33,55 @@ make -j<N>
 
 Tests will be located under `/code/build/ut/unit-tests`, which is an executable you can run.
 
+### Building & running with Nix
+
+If you have [Nix](https://nixos.org/) with flakes enabled:
+
+```bash
+# Run directly (builds and executes)
+nix run . -- -f traffic.json -r 100 -t 30
+
+# Build the binary
+nix build
+
+# Enter a dev shell with all dependencies
+nix develop
+```
+
+To install hermes into your system via `nix profile`:
+
+```bash
+nix profile install .
+```
+
+Or as a NixOS module input in your system flake:
+
+```nix
+{
+  inputs.hermes.url = "github:jgomezselles/hermes";
+
+  outputs = { hermes, ... }: {
+    nixosConfigurations.my-machine = {
+      environment.systemPackages = [ hermes.packages.x86_64-linux.default ];
+    };
+  };
+}
+```
+
+#### Nix container image
+
+Build a container image (OCI tarball) and load it into Docker:
+
+```bash
+nix build .#container
+docker load < result
+docker run --rm localhost/hermes:latest -f /path/to/traffic.json
+```
+
+This execution uses [nixpkgs dockerTools](https://ryantm.github.io/nixpkgs/builders/images/dockertools)
+and the output should be equivalent to a "FROM scratch" image, without any
+other binary rather than `hermes`.
+
 ## Format
 
 To format the code, `clang-format` is used (currently version 7), to run `clang-format`you can either install it in

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,136 @@
+{
+  description = "Hermes - HTTP/2 traffic generator";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        # Use unmodified libnghttp2_asio (it already depends on boost186)
+        libnghttp2_asio = pkgs.libnghttp2_asio;
+
+        # Enable HTTP client support in OpenTelemetry SDK
+        otel-cpp = pkgs.opentelemetry-cpp.override { enableHttp = true; };
+
+        # Build rapidjson with std::regex for JSON Schema validation
+        rapidjson = pkgs.rapidjson.overrideAttrs (old: {
+          cmakeFlags = (old.cmakeFlags or []) ++ [
+            "-DRAPIDJSON_SCHEMA_USE_STDREGEX=ON"
+            "-DRAPIDJSON_SCHEMA_USE_INTERNALREGEX=OFF"
+          ];
+        });
+
+        hermes = pkgs.stdenv.mkDerivation {
+          pname = "hermes";
+          version = "0.0.5";
+          src = ./.;
+
+          nativeBuildInputs = [ pkgs.cmake ];
+
+          # Use boost186 to match libnghttp2_asio's boost version,
+          # avoiding ABI/header incompatibilities
+          buildInputs = [
+            libnghttp2_asio
+            otel-cpp
+            pkgs.boost186
+            pkgs.curl
+            pkgs.gtest
+            pkgs.openssl
+            pkgs.protobuf
+            rapidjson
+          ];
+
+          cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp src/hermes $out/bin/
+          '';
+
+          meta = with pkgs.lib; {
+            description = "HTTP/2 traffic generator";
+            homepage = "https://github.com/jgomezselles/hermes";
+            license = licenses.mit;
+            platforms = platforms.linux;
+          };
+        };
+        container = pkgs.dockerTools.buildImage {
+          name = "hermes";
+          tag = "latest";
+          copyToRoot = pkgs.buildEnv {
+            name = "image-root";
+            paths = [ hermes ];
+            pathsToLink = [ "/bin" ];
+          };
+          config = {
+            Entrypoint = [ "${hermes}/bin/hermes" ];
+            Env = [ "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt" ];
+          };
+        };
+      in {
+        packages.default = hermes;
+        packages.hermes = hermes;
+        packages.container = container;
+
+        apps.default = flake-utils.lib.mkApp {
+          drv = hermes;
+          exePath = "/bin/hermes";
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.cmake
+            pkgs.gtest
+            libnghttp2_asio
+            otel-cpp
+            pkgs.boost186
+            pkgs.curl
+            pkgs.openssl
+            pkgs.protobuf
+            rapidjson
+          ];
+        };
+      }
+    ) // {
+      # Overlay so consumers can add hermes to their nixpkgs: `nixpkgs.overlays = [ hermes.overlays.default ]` -> `pkgs.hermes`
+      overlays.default = final: prev: {
+        hermes = prev.stdenv.mkDerivation {
+          pname = "hermes";
+          version = "0.0.5";
+          src = ./.;
+          nativeBuildInputs = [ prev.cmake ];
+          buildInputs = [
+            prev.libnghttp2_asio
+            (prev.opentelemetry-cpp.override { enableHttp = true; })
+            prev.boost186
+            prev.curl
+            prev.gtest
+            prev.openssl
+            prev.protobuf
+            (prev.rapidjson.overrideAttrs (old: {
+              cmakeFlags = (old.cmakeFlags or []) ++ [
+                "-DRAPIDJSON_SCHEMA_USE_STDREGEX=ON"
+                "-DRAPIDJSON_SCHEMA_USE_INTERNALREGEX=OFF"
+              ];
+            }))
+          ];
+          cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
+          installPhase = ''
+            mkdir -p $out/bin
+            cp src/hermes $out/bin/
+          '';
+          meta = with prev.lib; {
+            description = "HTTP/2 traffic generator";
+            homepage = "https://github.com/jgomezselles/hermes";
+            license = licenses.mit;
+            platforms = platforms.linux;
+          };
+        };
+      };
+    };
+}

--- a/src/http2_client/connection.cpp
+++ b/src/http2_client/connection.cpp
@@ -8,7 +8,7 @@ using nghttp2::asio_http2::client::session;
 
 namespace
 {
-nghttp2::asio_http2::client::session create_session(boost::asio::io_service& io_service,
+nghttp2::asio_http2::client::session create_session(boost::asio::io_context& io_ctx,
                                                     const std::string& h, const std::string& p,
                                                     const bool secure_session)
 {
@@ -18,18 +18,18 @@ nghttp2::asio_http2::client::session create_session(boost::asio::io_service& io_
         boost::asio::ssl::context tls_ctx(boost::asio::ssl::context::sslv23);
         tls_ctx.set_default_verify_paths();
         nghttp2::asio_http2::client::configure_tls_context(ec, tls_ctx);
-        return nghttp2::asio_http2::client::session(io_service, tls_ctx, h, p);
+        return nghttp2::asio_http2::client::session(io_ctx, tls_ctx, h, p);
     }
 
-    return nghttp2::asio_http2::client::session(io_service, h, p);
+    return nghttp2::asio_http2::client::session(io_ctx, h, p);
 }
 }  // namespace
 
 namespace http2_client
 {
 connection::connection(const std::string& h, const std::string& p, bool secure_session)
-    : svc_work(boost::asio::io_service::work(io_service)),
-      session(create_session(io_service, h, p, secure_session))
+    : svc_work(boost::asio::make_work_guard(io_context)),
+      session(create_session(io_context, h, p, secure_session))
 {
     session.on_connect(
         [this, h, p](tcp::resolver::iterator)
@@ -47,12 +47,12 @@ connection::connection(const std::string& h, const std::string& p, bool secure_s
             notify_close();
         });
 
-    worker = std::thread([this] { io_service.run(); });
+    worker = std::thread([this] { io_context.run(); });
 }
 
 connection::~connection()
 {
-    io_service.stop();
+    io_context.stop();
 
     if (worker.joinable())
     {

--- a/src/http2_client/connection.hpp
+++ b/src/http2_client/connection.hpp
@@ -52,8 +52,8 @@ private:
     void notify_close();
 
     /// ASIO attributes
-    boost::asio::io_service io_service;
-    boost::asio::io_service::work svc_work;
+    boost::asio::io_context io_context;
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> svc_work;
     nghttp2::asio_http2::client::session session;
 
     /// Class attributes


### PR DESCRIPTION
Add a nix flake so the project may be compiled and installed using nix and flake.

CHANGES IN SRC

use io_service() to match libnghttp2_asio API

libnghttp2_asio is built against boost186 (1.86.0), which exposes session::io_service() rather than session::io_context(). While boost::asio::io_context itself exists as a type in 1.86.0, the accessor method on the nghttp2 session class retains the older name. Switch the call to io_service() to match the library's actual API and fix the build.