### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           lcov -a base-coverage.info  -a test-coverage.info  -o total-coverage.info
     -
       name: Upload coverage to Coveralls
-      uses: coverallsapp/github-action@v2
+      uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2 - update: gh api repos/coverallsapp/github-action/git/ref/tags/v2 --jq '.object.sha'
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: total-coverage.info
@@ -74,10 +74,10 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3 - update: gh api repos/docker/setup-buildx-action/git/ref/tags/v3 --jq '.object.sha'
       -
         name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6 - update: gh api repos/docker/build-push-action/git/ref/tags/v6 --jq '.object.sha'
         with:
           context: .
           file: ./docker/Dockerfile
@@ -105,10 +105,10 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3 - update: gh api repos/docker/setup-buildx-action/git/ref/tags/v3 --jq '.object.sha'
       -
         name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6 - update: gh api repos/docker/build-push-action/git/ref/tags/v6 --jq '.object.sha'
         with:
           context: .
           file: ./docker/server-mock/Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           lcov -a base-coverage.info  -a test-coverage.info  -o total-coverage.info
     -
       name: Upload coverage to Coveralls
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: total-coverage.info
@@ -71,10 +71,10 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile
@@ -102,10 +102,10 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/server-mock/Dockerfile
@@ -127,7 +127,7 @@ jobs:
     steps:
     -
       name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     -
       name: Trim commit id
       run: echo COMMIT_ID=${COMMIT_ID::7} >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
 
   formatting-check:
@@ -136,7 +139,6 @@ jobs:
       uses: helm/kind-action@2a525709fd0874b75d7ae842d257981b0e0f557d
       with:
         cluster_name: "kind"
-        kubectl_version: "v1.22.1"
     -
       name: Download server-mock
       uses: actions/download-artifact@v4.1.7
@@ -189,3 +191,18 @@ jobs:
       run: |
         HERMES_POD=$(kubectl get pod -l app.kubernetes.io/name=hermes -o jsonpath="{.items[0].metadata.name}")
         kubectl exec $HERMES_POD -- hermes -p1 -t10 -r1000
+    -
+      name: Dump debug info
+      if: failure()
+      run: |
+        echo "=== Pods ==="
+        kubectl get pods -A
+        echo "=== Events ==="
+        kubectl get events -A --sort-by='.lastTimestamp'
+        echo "=== Pod descriptions ==="
+        kubectl describe pods -A
+        echo "=== Logs ==="
+        for pod in $(kubectl get pods -o name); do
+          echo "--- $pod ---"
+          kubectl logs $pod --all-containers --tail=50 || true
+        done

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
   pull_request:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
 
   sonar:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -14,11 +14,11 @@ jobs:
       SONAR_SCANNER_VERSION: 4.6.1.2450 # Find the latest version in the "Linux" link on this page:
                                         # https://docs.sonarcloud.io/advanced-setup/ci-based-analysis/sonarscanner-cli
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
       - name: Install boost
@@ -42,7 +42,7 @@ jobs:
           sudo make -j install
           cd .. && sudo rm -rf nghttp2*
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar

--- a/ft/h2server/otel.go
+++ b/ft/h2server/otel.go
@@ -8,7 +8,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 
 	"go.opentelemetry.io/otel/log/global"
 	"go.opentelemetry.io/otel/propagation"

--- a/helm/example-hermes/Chart.yaml
+++ b/helm/example-hermes/Chart.yaml
@@ -9,12 +9,3 @@ dependencies:
   - name: hermes
     version: 0.0.3
     repository: https://jgomezselles.github.io/hermes-charts
-  - name: victoria-metrics-single
-    version: 0.12.7
-    repository: https://victoriametrics.github.io/helm-charts
-  - name: grafana
-    version: 6.58.8
-    repository: https://grafana.github.io/helm-charts
-  - name: tempo
-    version: 1.7.0
-    repository: https://grafana.github.io/helm-charts

--- a/helm/example-hermes/values.yaml
+++ b/helm/example-hermes/values.yaml
@@ -19,47 +19,5 @@ hermes:
     repository: ghcr.io/jgomezselles/hermes
     tag: 0.0.7
   o11y:
-    metrics_endpoint: http://victoria-svc:8428/opentelemetry/api/v1/push
-    traces_endpoint: http://hermes-tempo:4318/v1/traces
-
-victoria-metrics-single:
-  server:
-    fullnameOverride: "victoria-svc"
-    persistentVolume:
-      enabled: false
-
-grafana:
-  adminPassword: admin
-  datasources:
-    datasources.yaml:
-      apiVersion: 1
-      datasources:
-      - name: Prometheus
-        type: prometheus
-        url: http://victoria-svc:8428
-        access: proxy
-        isDefault: true
-        uid: hermes-prometheus-datasource
-      - name: Tempo
-        uid: tempo
-        type: tempo
-        url: http://hermes-tempo:3100
-        isDefault: false
-      deleteDatasources:
-      - name: Prometheus
-
-  dashboardProviders:
-   dashboardproviders.yaml:
-     apiVersion: 1
-     providers:
-     - name: 'default'
-       orgId: 1
-       folder: ''
-       type: file
-       disableDeletion: false
-       editable: true
-       options:
-         path: /var/lib/grafana/dashboards/default
-
-  dashboardsConfigMaps:
-    default: "hermes-dashboard"
+    metrics_endpoint: ""
+    traces_endpoint: ""


### PR DESCRIPTION
## What changed

**Node 24 compatibility (`ci.yml` + `sonar.yml`)**
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at workflow level to silence Node 20 deprecation warnings from actions that haven't yet migrated their runtime (e.g. `actions/checkout@v4`)

**Action version bumps (`ci.yml`)**
- `actions/checkout@v2` → `@v4` (one remaining inconsistent usage in `test-example-hermes`)
- `docker/setup-buildx-action@v1` → `@v3` (both build jobs)
- `docker/build-push-action@v2` / `@v4` → `@v6` (both build jobs)
- `coverallsapp/github-action@master` → `@v2` (also pins to a stable tag)

**Action version bumps (`sonar.yml`)**
- `actions/checkout@v2` → `@v4`
- `actions/setup-java@v1` → `@v4`
- `actions/cache@v1` → `@v4`

**SHA pinning for third-party actions (`ci.yml`)**
- `coverallsapp/github-action`, `docker/build-push-action`, `docker/setup-buildx-action` pinned to full commit SHAs to prevent supply chain attacks. Each has an inline comment with the `gh api` command to refresh the SHA on future updates.

**KinD / helm test fixes (`ci.yml`)**
- Removed pinned `kubectl_version: v1.22.1` (EOL) from `helm/kind-action`
- Removed heavy dependencies for faster installation and test
- Added a `Dump debug info` step with `if: failure()` that outputs pod list, sorted events, descriptions and last 50 log lines per container

**Server-mock OTel fix (`ft/h2server/otel.go`)**
- Bumped semconv import from `v1.37.0` to `v1.40.0` to match the schema URL used by `resource.Default()` in the latest OTel SDK, fixing the `conflicting Schema URL` error at startup

🤖 Generated with help of [Claude Code](https://claude.com/claude-code)